### PR TITLE
Change PNG-as-text to generate on demand instead of constantly

### DIFF
--- a/src/components/Paint/Index.jsx
+++ b/src/components/Paint/Index.jsx
@@ -26,8 +26,8 @@ export default class Index extends React.Component {
         </div>
         <div className="painter-output">
           <h3>Painted Classification Data as Text</h3>
-          <textarea ref="output"></textarea>
-          <a ref="download" download="classification.png" href="">Download as PNG</a>
+          <input type="text" ref="output" />
+          <a ref="download" download="classification.png" onClick={this.download.bind(this)} href="">Download as PNG</a>
           </div>
       </div>
     );
@@ -85,10 +85,13 @@ export default class Index extends React.Component {
     this.classifierContext.arc(pointer.x, pointer.y, RADIUS, 0, 2*Math.PI);
     this.classifierContext.fill();
     this.classifierContext.closePath();
-    
+  }
+  
+  download() {
     const dataPng = this.refs.classifier.toDataURL("image/png");
     this.refs.output.value = dataPng;
     this.refs.download.href = dataPng;
+    return true;
   }
   
   updateSize() {


### PR DESCRIPTION
## PR Overview
Previously, the PNG-as-text data is generated every time paint() is called (i.e. always). Now, we only generate the PNG-as-text data when the Download button is clicked, to reduce resource usage.
